### PR TITLE
workaround to recover panic when send on close channel.

### DIFF
--- a/server_conn.go
+++ b/server_conn.go
@@ -201,6 +201,13 @@ func (c *serverConn) OnPacket(r *parser.PacketDecoder) {
 	if s := c.getState(); s != stateNormal && s != stateUpgrading {
 		return
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok && e.Error() == "send on closed channel" {
+				fmt.Println("recover from send on closed channel")
+			}
+		}
+	}()
 	switch r.Type() {
 	case parser.OPEN:
 	case parser.CLOSE:


### PR DESCRIPTION

```
matt@matt-nb ~/.g/p/g/g/s/go-engine.io> go test . -v
=== RUN   TestConnIoutil

  Reader 
    Normal read ✔✔✔✔
      Wait close 
        Close again ✔


5 total assertions


  Wrtier 
    Normal write ✔✔
    Sync ✔
      Close again ✔


9 total assertions

--- PASS: TestConnIoutil (0.40s)
=== RUN   TestConn

  Create conn 
    without transport ✔✔
    with invalid transport ✔✔
    ok 
      with polling ✔✔✔✔
      with websocket ✔✔✔


20 total assertions


  Upgrade conn 
    polling to websocket ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
    close when upgrading ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


70 total assertions


  Closing 
    close timeout by polling ✔✔✔✔✔✔✔✔
    close by websocket ✔✔✔2017/02/24 09:41:21 http: response.WriteHeader on hijacked connection
✔✔


83 total assertions

--- PASS: TestConn (7.52s)
=== RUN   TestServer

  Setup server ✔✔✔✔✔✔✔


90 total assertions


  Create server 
    Test new id ✔✔


92 total assertions


  Max connections ✔✔✔✔


96 total assertions

--- PASS: TestServer (0.00s)
=== RUN   TestServerSessions

  Server sessions ✔✔✔✔✔


101 total assertions

--- PASS: TestServerSessions (0.00s)
PASS
ok      go-engine.io    7.924s
```